### PR TITLE
Fix duplicated attribute problem

### DIFF
--- a/lib/src/main/java/com/wind/meditor/visitor/ModifyAttributeVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ModifyAttributeVisitor.java
@@ -45,8 +45,9 @@ public class ModifyAttributeVisitor extends NodeVisitor {
                     continue;
                 }
 
-                if (Utils.isEqual(ns, attributeItem.getNamespace())
-                        && Utils.isEqual(name, attributeItem.getName())) {
+                if ((Utils.isEqual(ns, attributeItem.getNamespace())
+                        && Utils.isEqual(name, attributeItem.getName()))
+                        || (resourceId >= 0 && resourceId == attributeItem.getResourceId())) {
                     hasBeenAddedAttributeList.add(attributeItem);
                     newObj = attributeItem.getValue();
                     break;


### PR DESCRIPTION
If the key of an attribute is specified as a resource ID, the attribute may be added (duplicated) rather than overwritten by an existing attribute.

1. Download [this AndroidManifest.xml](https://www.mediafire.com/file/c3tlr079vbvpfle/AndroidManifest.xml/file)
2. Run ManifestEditor to edit android:appComponentFactory.

        java -jar ManifestEditor-1.0.2.jar -f -aa android-appComponentFactory:ThisIsUpdatedValue AndroidManifest.xml
3. View the generated xml with a AXML viewer such as [JADX](https://github.com/skylot/jadx).
  There are two attributes with the same names.
  ![duplicatedattribute](https://user-images.githubusercontent.com/42905588/186880641-d2ca781f-6dfd-4dfb-9ba8-e496bf2fdd99.png)

This PR fixes this problem by checking the name of the attribute not only as a string but also as a resource ID in ModifyAttributeVisitor.