### PR TITLE
When processing the apk file, copy the zip compression method.

### DIFF
--- a/lib/src/main/java/com/wind/meditor/core/FileProcesser.java
+++ b/lib/src/main/java/com/wind/meditor/core/FileProcesser.java
@@ -53,6 +53,12 @@ public class FileProcesser {
                     ZipEntry zosEntry = new ZipEntry(entry.getName());
                     zosEntry.setComment(entry.getComment());
                     zosEntry.setExtra(entry.getExtra());
+                    zosEntry.setMethod(entry.getMethod());
+                    if (entry.getMethod() == ZipEntry.STORED) {
+                        zosEntry.setSize(entry.getSize());
+                        zosEntry.setCompressedSize(entry.getSize());
+                        zosEntry.setCrc(entry.getCrc());
+                    }
 
                     zipOutputStream.putNextEntry(zosEntry);
                     if ("AndroidManifest.xml".equals(zipEntryName)) {


### PR DESCRIPTION
If the zip compression method is not copied, the default DEFLATED compression method is set for all entries and in some cases, e.g. for resources.arsc, Android is not happy when installing the file because it requires them to be uncompressed.