### PR TITLE
Add APIs for various permissions and authorities mapping

### DIFF
--- a/lib/src/main/java/com/wind/meditor/property/AttributeMapper.java
+++ b/lib/src/main/java/com/wind/meditor/property/AttributeMapper.java
@@ -1,0 +1,5 @@
+package com.wind.meditor.property;
+
+public interface AttributeMapper<T> {
+    T map(T value);
+}

--- a/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
+++ b/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
@@ -18,6 +18,8 @@ public class ModificationProperty {
     private List<AttributeItem> manifestAttributeList = new ArrayList<>();
     private List<AttributeItem> usesSdkAttributeList = new ArrayList<>();
 
+    private PermissionMapper permissionMapper;
+
     public List<String> getUsesPermissionList() {
         return usesPermissionList;
     }
@@ -69,6 +71,15 @@ public class ModificationProperty {
 
     public ModificationProperty addDeleteMetaData(String name) {
         this.deleteMetaDataList.add(new MetaData(name, ""));
+        return this;
+    }
+
+    public PermissionMapper getPermissionMapper() {
+        return permissionMapper;
+    }
+
+    public ModificationProperty setPermissionMapper(PermissionMapper mapper) {
+        this.permissionMapper = mapper;
         return this;
     }
 

--- a/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
+++ b/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
@@ -19,6 +19,7 @@ public class ModificationProperty {
     private List<AttributeItem> usesSdkAttributeList = new ArrayList<>();
 
     private PermissionMapper permissionMapper;
+    private AttributeMapper<String> providerAuthorityMapper;
 
     public List<String> getUsesPermissionList() {
         return usesPermissionList;
@@ -80,6 +81,15 @@ public class ModificationProperty {
 
     public ModificationProperty setPermissionMapper(PermissionMapper mapper) {
         this.permissionMapper = mapper;
+        return this;
+    }
+
+    public AttributeMapper<String> getAuthorityMapper() {
+        return providerAuthorityMapper;
+    }
+
+    public ModificationProperty setAuthorityMapper(AttributeMapper<String> mapper) {
+        this.providerAuthorityMapper = mapper;
         return this;
     }
 

--- a/lib/src/main/java/com/wind/meditor/property/PermissionMapper.java
+++ b/lib/src/main/java/com/wind/meditor/property/PermissionMapper.java
@@ -1,0 +1,7 @@
+package com.wind.meditor.property;
+
+import com.wind.meditor.utils.PermissionType;
+
+public interface PermissionMapper {
+  String map(PermissionType type, String permission);
+}

--- a/lib/src/main/java/com/wind/meditor/utils/NodeValue.java
+++ b/lib/src/main/java/com/wind/meditor/utils/NodeValue.java
@@ -1,5 +1,8 @@
 package com.wind.meditor.utils;
 
+import java.util.Arrays;
+import java.util.List;
+
 public final class NodeValue {
     private NodeValue(){}
 
@@ -26,6 +29,13 @@ public final class NodeValue {
         public static final String MAX_SDK_VERSION="maxSdkVersion";
         public static final String MIN_SDK_VERSION="minSdkVersion";
         public static final String TARGET_SDK_VERSION="targetSdkVersion";
+    }
+
+    public static final class Permission{
+        public static final String TAG_NAME = "permission";
+
+        public static final String NAME="name";
+        public static final String PROTECTION_LEVEL="protectionLevel";
     }
 
     public static final class UsesPermission{
@@ -64,7 +74,35 @@ public final class NodeValue {
         public static final String ENABLED="enabled";
         public static final String DESCRIPTION="description";
         public static final String PROCESS="process";
+
+        public static abstract class Component {
+            public static final String NAME = "name";
+            public static final String ENABLED = "enabled";
+            public static final String PROCESS = "process";
+            public static final String PERMISSION = "permission";
+        }
+
+        public static final class Activity extends Component {
+            public static final String TAG_NAME = "activity";
+        }
+
+        public static final class Service extends Component {
+            public static final String TAG_NAME = "service";
+        }
+
+        public static final class Receiver extends Component {
+            public static final String TAG_NAME = "receiver";
+        }
+
+        public static final class Provider extends Component {
+            public static final String TAG_NAME = "provider";
+            public static final String AUTHORITIES = "authorities";
+            public static final String READ_PERMISSION = "readPermission";
+            public static final String WRITE_PERMISSION = "writePermission";
+        }
+
+        public static final List<String> COMPONENT_TAGS = Arrays.asList(
+                Activity.TAG_NAME, Service.TAG_NAME, Receiver.TAG_NAME, Provider.TAG_NAME
+        );
     }
-
-
 }

--- a/lib/src/main/java/com/wind/meditor/utils/PermissionType.java
+++ b/lib/src/main/java/com/wind/meditor/utils/PermissionType.java
@@ -1,0 +1,7 @@
+package com.wind.meditor.utils;
+
+public enum PermissionType {
+  USES_PERMISSION,
+  DECLARED_PERMISSION,
+  COMPONENT_PERMISSION
+}

--- a/lib/src/main/java/com/wind/meditor/visitor/ApplicationComponentTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ApplicationComponentTagVisitor.java
@@ -1,24 +1,43 @@
 package com.wind.meditor.visitor;
 
+import com.wind.meditor.property.AttributeMapper;
 import com.wind.meditor.property.PermissionMapper;
 import com.wind.meditor.utils.NodeValue;
 import com.wind.meditor.utils.PermissionType;
 import pxb.android.axml.NodeVisitor;
 
+import java.util.Arrays;
+
+import static java.util.stream.Collectors.joining;
+
 public class ApplicationComponentTagVisitor extends NodeVisitor {
     private final PermissionMapper permissionMapper;
+    private final AttributeMapper<String> authorityMapper;
 
-    ApplicationComponentTagVisitor(NodeVisitor nv, PermissionMapper permissionMapper) {
+    ApplicationComponentTagVisitor(NodeVisitor nv,
+                                   PermissionMapper permissionMapper,
+                                   AttributeMapper<String> authorityMapper) {
         super(nv);
         this.permissionMapper = permissionMapper;
+        this.authorityMapper = authorityMapper;
     }
 
     @Override
     public void attr(String ns, String name, int resourceId, int type, Object obj) {
-        if (isPermissionTag(name) && obj instanceof String && permissionMapper != null) {
-            obj = permissionMapper.map(PermissionType.COMPONENT_PERMISSION, (String) obj);
+        if (obj instanceof String) {
+            if (isPermissionTag(name) && permissionMapper != null) {
+                obj = permissionMapper.map(PermissionType.COMPONENT_PERMISSION, (String) obj);
+            }
+            if (NodeValue.Application.Provider.AUTHORITIES.equals(name) && authorityMapper != null) {
+                obj = mapAuthorities((String) obj);
+            }
         }
         super.attr(ns, name, resourceId, type, obj);
+    }
+
+    private Object mapAuthorities(String authorities) {
+        return !authorities.contains(";") ? authorityMapper.map(authorities) :
+                Arrays.stream(authorities.split(";")).map(s -> authorityMapper.map(s.trim())).collect(joining("; "));
     }
 
     private boolean isPermissionTag(String name) {

--- a/lib/src/main/java/com/wind/meditor/visitor/ApplicationComponentTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ApplicationComponentTagVisitor.java
@@ -1,0 +1,29 @@
+package com.wind.meditor.visitor;
+
+import com.wind.meditor.property.PermissionMapper;
+import com.wind.meditor.utils.NodeValue;
+import com.wind.meditor.utils.PermissionType;
+import pxb.android.axml.NodeVisitor;
+
+public class ApplicationComponentTagVisitor extends NodeVisitor {
+    private final PermissionMapper permissionMapper;
+
+    ApplicationComponentTagVisitor(NodeVisitor nv, PermissionMapper permissionMapper) {
+        super(nv);
+        this.permissionMapper = permissionMapper;
+    }
+
+    @Override
+    public void attr(String ns, String name, int resourceId, int type, Object obj) {
+        if (isPermissionTag(name) && obj instanceof String && permissionMapper != null) {
+            obj = permissionMapper.map(PermissionType.COMPONENT_PERMISSION, (String) obj);
+        }
+        super.attr(ns, name, resourceId, type, obj);
+    }
+
+    private boolean isPermissionTag(String name) {
+        return name.equals(NodeValue.Application.Component.PERMISSION) ||
+               name.equals(NodeValue.Application.Provider.READ_PERMISSION) ||
+               name.equals(NodeValue.Application.Provider.WRITE_PERMISSION);
+    }
+}

--- a/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
@@ -2,6 +2,7 @@ package com.wind.meditor.visitor;
 
 import com.wind.meditor.property.AttributeItem;
 import com.wind.meditor.property.ModificationProperty;
+import com.wind.meditor.property.PermissionMapper;
 import com.wind.meditor.utils.NodeValue;
 
 import java.util.List;
@@ -15,15 +16,18 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
     private List<ModificationProperty.MetaData> metaDataList;
     private List<ModificationProperty.MetaData> deleteMetaDataList;
     private ModificationProperty.MetaData curMetaData;
+    private PermissionMapper permissionMapper;
 
     private static final String META_DATA_FLAG = "meta_data_flag";
 
     ApplicationTagVisitor(NodeVisitor nv, List<AttributeItem> modifyAttributeList,
                           List<ModificationProperty.MetaData> metaDataList,
-                          List<ModificationProperty.MetaData> deleteMetaDataList) {
+                          List<ModificationProperty.MetaData> deleteMetaDataList,
+                          PermissionMapper permissionMapper) {
         super(nv, modifyAttributeList);
         this.metaDataList = metaDataList;
         this.deleteMetaDataList = deleteMetaDataList;
+        this.permissionMapper = permissionMapper;
     }
 
     @Override
@@ -38,6 +42,8 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
                 && deleteMetaDataList != null && !deleteMetaDataList.isEmpty()) {
             NodeVisitor nv = super.child(ns, name);
             return new DeleteMetaDataVisitor(nv, deleteMetaDataList);
+        } else if (NodeValue.Application.COMPONENT_TAGS.contains(name)) {
+            return new ApplicationComponentTagVisitor(super.child(ns, name), permissionMapper);
         }
         return super.child(ns, name);
     }

--- a/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
@@ -1,6 +1,7 @@
 package com.wind.meditor.visitor;
 
 import com.wind.meditor.property.AttributeItem;
+import com.wind.meditor.property.AttributeMapper;
 import com.wind.meditor.property.ModificationProperty;
 import com.wind.meditor.property.PermissionMapper;
 import com.wind.meditor.utils.NodeValue;
@@ -17,17 +18,19 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
     private List<ModificationProperty.MetaData> deleteMetaDataList;
     private ModificationProperty.MetaData curMetaData;
     private PermissionMapper permissionMapper;
+    private AttributeMapper<String> authorityMapper;
 
     private static final String META_DATA_FLAG = "meta_data_flag";
 
     ApplicationTagVisitor(NodeVisitor nv, List<AttributeItem> modifyAttributeList,
                           List<ModificationProperty.MetaData> metaDataList,
                           List<ModificationProperty.MetaData> deleteMetaDataList,
-                          PermissionMapper permissionMapper) {
+                          PermissionMapper permissionMapper, AttributeMapper<String> authorityMapper) {
         super(nv, modifyAttributeList);
         this.metaDataList = metaDataList;
         this.deleteMetaDataList = deleteMetaDataList;
         this.permissionMapper = permissionMapper;
+        this.authorityMapper = authorityMapper;
     }
 
     @Override
@@ -43,7 +46,7 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
             NodeVisitor nv = super.child(ns, name);
             return new DeleteMetaDataVisitor(nv, deleteMetaDataList);
         } else if (NodeValue.Application.COMPONENT_TAGS.contains(name)) {
-            return new ApplicationComponentTagVisitor(super.child(ns, name), permissionMapper);
+            return new ApplicationComponentTagVisitor(super.child(ns, name), permissionMapper, authorityMapper);
         }
         return super.child(ns, name);
     }

--- a/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
@@ -28,13 +28,13 @@ public class ManifestTagVisitor extends ModifyAttributeVisitor {
 
         if (ns != null && (NodeValue.UsesPermission.TAG_NAME).equals(name)) {
             NodeVisitor child = super.child(null, NodeValue.UsesPermission.TAG_NAME);
-            return new UserPermissionTagVisitor(child, null, ns);
+            return new UserPermissionTagVisitor(child, null, ns, properties.getPermissionMapper());
         }
 
         NodeVisitor child = super.child(ns, name);
         if (NodeValue.Application.TAG_NAME.equals(name)) {
             return new ApplicationTagVisitor(child, properties.getApplicationAttributeList(),
-                    properties.getMetaDataList(), properties.getDeleteMetaDataList());
+                    properties.getMetaDataList(), properties.getDeleteMetaDataList(), properties.getPermissionMapper());
         }
 
         if (NodeValue.UsesSDK.TAG_NAME.equals(name)) {
@@ -42,7 +42,11 @@ public class ManifestTagVisitor extends ModifyAttributeVisitor {
         }
 
         if (NodeValue.UsesPermission.TAG_NAME.equals(name)) {
-            return new UserPermissionTagVisitor(child, getUsesPermissionGetter(), null);
+            return new UserPermissionTagVisitor(child, getUsesPermissionGetter(), null, properties.getPermissionMapper());
+        }
+
+        if (NodeValue.Permission.TAG_NAME.equals(name)) {
+            return new PermissionTagVisitor(child, properties.getPermissionMapper());
         }
         return child;
     }

--- a/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
@@ -34,7 +34,8 @@ public class ManifestTagVisitor extends ModifyAttributeVisitor {
         NodeVisitor child = super.child(ns, name);
         if (NodeValue.Application.TAG_NAME.equals(name)) {
             return new ApplicationTagVisitor(child, properties.getApplicationAttributeList(),
-                    properties.getMetaDataList(), properties.getDeleteMetaDataList(), properties.getPermissionMapper());
+                    properties.getMetaDataList(), properties.getDeleteMetaDataList(),
+                    properties.getPermissionMapper(), properties.getAuthorityMapper());
         }
 
         if (NodeValue.UsesSDK.TAG_NAME.equals(name)) {

--- a/lib/src/main/java/com/wind/meditor/visitor/PermissionTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/PermissionTagVisitor.java
@@ -1,0 +1,23 @@
+package com.wind.meditor.visitor;
+
+import com.wind.meditor.property.PermissionMapper;
+import com.wind.meditor.utils.NodeValue;
+import com.wind.meditor.utils.PermissionType;
+import pxb.android.axml.NodeVisitor;
+
+public class PermissionTagVisitor extends NodeVisitor {
+    private final PermissionMapper permissionMapper;
+
+    PermissionTagVisitor(NodeVisitor nv, PermissionMapper permissionMapper) {
+        super(nv);
+        this.permissionMapper = permissionMapper;
+    }
+
+    @Override
+    public void attr(String ns, String name, int resourceId, int type, Object obj) {
+        if (NodeValue.Permission.NAME.equals(name) && obj instanceof String && permissionMapper != null) {
+            obj = permissionMapper.map(PermissionType.DECLARED_PERMISSION, (String) obj);
+        }
+        super.attr(ns, name, resourceId, type, obj);
+    }
+}

--- a/lib/src/main/java/com/wind/meditor/visitor/UserPermissionTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/UserPermissionTagVisitor.java
@@ -1,7 +1,9 @@
 package com.wind.meditor.visitor;
 
 import com.wind.meditor.property.AttributeItem;
+import com.wind.meditor.property.PermissionMapper;
 import com.wind.meditor.utils.NodeValue;
+import com.wind.meditor.utils.PermissionType;
 import com.wind.meditor.utils.Utils;
 
 import pxb.android.axml.NodeVisitor;
@@ -9,10 +11,12 @@ import pxb.android.axml.NodeVisitor;
 class UserPermissionTagVisitor extends NodeVisitor {
 
     private IUsesPermissionGetter permissionGetter;
+    private PermissionMapper permissionMapper;
 
-    UserPermissionTagVisitor(NodeVisitor nv, IUsesPermissionGetter permissionGetter, String permissionTobeAdded) {
+    UserPermissionTagVisitor(NodeVisitor nv, IUsesPermissionGetter permissionGetter, String permissionTobeAdded, PermissionMapper mapper) {
         super(nv);
         this.permissionGetter = permissionGetter;
+        this.permissionMapper = mapper;
 
         if (!Utils.isNullOrEmpty(permissionTobeAdded)) {
             AttributeItem attributeItem = new AttributeItem(NodeValue.UsesPermission.NAME, permissionTobeAdded);
@@ -27,6 +31,9 @@ class UserPermissionTagVisitor extends NodeVisitor {
     @Override
     public void attr(String ns, String name, int resourceId, int type, Object obj) {
         if (obj instanceof String && permissionGetter != null) {
+            if (NodeValue.UsesPermission.NAME.equals(name) && permissionMapper != null) {
+                obj = permissionMapper.map(PermissionType.USES_PERMISSION, (String) obj);
+            }
             permissionGetter.onPermissionGetted((String) obj);
         }
         super.attr(ns, name, resourceId, type, obj);


### PR DESCRIPTION
The permission mapping feature lets users choose which permissions to change without changing all of them at once. This is because not all types of permissions need to be changed in every situation. It's made using the [PermissionMapper](https://github.com/WindySha/ManifestEditor/blob/6d3f0d943b92a552853157aaa721d9b78bfee483/lib/src/main/java/com/wind/meditor/property/PermissionMapper.java) interface. When set, it's called for each permission with its [type](https://github.com/WindySha/ManifestEditor/blob/6d3f0d943b92a552853157aaa721d9b78bfee483/lib/src/main/java/com/wind/meditor/utils/PermissionType.java) (USES, DECLARED, COMPONENT). Developers or users can decide how to change a permission based on its type and value.

Note: Not all apps prefix permissions with their actual package name. That's why simply adding an option to replace the package name from all permissions won't work. The same applies to provider authorities.