### PR TITLE
Avoid wrapping attribute values for known types

### DIFF
--- a/lib/src/main/java/pxb/android/axml/AxmlParser.java
+++ b/lib/src/main/java/pxb/android/axml/AxmlParser.java
@@ -15,6 +15,7 @@
  */
 package pxb.android.axml;
 
+import static pxb.android.axml.NodeVisitor.TYPE_FIRST_INT;
 import static pxb.android.axml.NodeVisitor.TYPE_INT_BOOLEAN;
 import static pxb.android.axml.NodeVisitor.TYPE_STRING;
 
@@ -122,6 +123,15 @@ public class AxmlParser implements ResConst {
     public Object getAttrValue(int i) {
         int v = attrs.get(i * 5 + 4);
 
+        switch (getAttrType(i)) {
+        case TYPE_FIRST_INT:
+            return v;
+        case TYPE_STRING:
+            return strings[v];
+        case TYPE_INT_BOOLEAN:
+            return v != 0;
+        }
+
         if (i == idAttribute) {
             return ValueWrapper.wrapId(v, getAttrRawString(i));
         } else if (i == styleAttribute) {
@@ -130,14 +140,7 @@ public class AxmlParser implements ResConst {
             return ValueWrapper.wrapClass(v, getAttrRawString(i));
         }
 
-        switch (getAttrType(i)) {
-        case TYPE_STRING:
-            return strings[v];
-        case TYPE_INT_BOOLEAN:
-            return v != 0;
-        default:
-            return v;
-        }
+        return v;
     }
 
     public int getLineNumber() {


### PR DESCRIPTION
If an attribute has known type, we should return the value without wrapping it. It happens that when parsing the minSdkVersion attribute (<uses-sdk />) of the package `com.xunmeng.pinduoduo`, the condition `i == idAttribute` is valid, which causes invalid return value of `getAttrValue`. This commit fix the issue https://github.com/JingMatrix/LSPatch/issues/24