### PR TITLE
Feat: support add provider

### DIFF
--- a/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
+++ b/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
@@ -1,6 +1,7 @@
 package com.wind.meditor.property;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -20,6 +21,7 @@ public class ModificationProperty {
 
     private PermissionMapper permissionMapper;
     private AttributeMapper<String> providerAuthorityMapper;
+    private List<Provider> providerList = new ArrayList<>();
 
     public List<String> getUsesPermissionList() {
         return usesPermissionList;
@@ -36,6 +38,11 @@ public class ModificationProperty {
 
     public ModificationProperty addApplicationAttribute(AttributeItem item) {
         applicationAttributeList.add(item);
+        return this;
+    }
+
+    public ModificationProperty addProvider(HashMap<String,String> nameValue,String filterNameValue){
+        providerList.add(new Provider(nameValue,filterNameValue));
         return this;
     }
 
@@ -68,6 +75,10 @@ public class ModificationProperty {
 
     public List<MetaData> getDeleteMetaDataList() {
         return deleteMetaDataList;
+    }
+
+    public List<Provider> getProviderList(){
+        return providerList;
     }
 
     public ModificationProperty addDeleteMetaData(String name) {
@@ -112,6 +123,21 @@ public class ModificationProperty {
 
         public String getValue() {
             return value;
+        }
+    }
+
+    public static class Provider{
+        private HashMap<String,String> nameValue;
+        private String filterNameValue;
+        public Provider(HashMap<String,String> nameValue,String filterNameValue){
+            this.nameValue = nameValue;
+            this.filterNameValue = filterNameValue;
+        }
+        public HashMap<String,String> getNameValue(){
+            return nameValue;
+        }
+        public String getFilterNameValue(){
+            return filterNameValue;
         }
     }
 }

--- a/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
@@ -26,14 +26,15 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
     ApplicationTagVisitor(NodeVisitor nv, List<AttributeItem> modifyAttributeList,
                           List<ModificationProperty.MetaData> metaDataList,
                           List<ModificationProperty.MetaData> deleteMetaDataList,
-                          List<ModificationProperty.Provider> providerList, 
-                          PermissionMapper permissionMapper, AttributeMapper<String> authorityMapper) {
+                          PermissionMapper permissionMapper,
+                          AttributeMapper<String> authorityMapper,
+                          List<ModificationProperty.Provider> providerList) {
         super(nv, modifyAttributeList);
         this.metaDataList = metaDataList;
         this.deleteMetaDataList = deleteMetaDataList;
         this.permissionMapper = permissionMapper;
         this.authorityMapper = authorityMapper;
-        this.providerList = providerList;
+        this.providerList = providerList; // 儲存 providerList
     }
 
     @Override

--- a/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
@@ -14,9 +14,10 @@ import pxb.android.axml.NodeVisitor;
  */
 public class ApplicationTagVisitor extends ModifyAttributeVisitor {
 
+    private ModificationProperty.MetaData curMetaData;
     private List<ModificationProperty.MetaData> metaDataList;
     private List<ModificationProperty.MetaData> deleteMetaDataList;
-    private ModificationProperty.MetaData curMetaData;
+    private List<ModificationProperty.Provider> providerList;
     private PermissionMapper permissionMapper;
     private AttributeMapper<String> authorityMapper;
 
@@ -25,16 +26,19 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
     ApplicationTagVisitor(NodeVisitor nv, List<AttributeItem> modifyAttributeList,
                           List<ModificationProperty.MetaData> metaDataList,
                           List<ModificationProperty.MetaData> deleteMetaDataList,
+                          List<ModificationProperty.Provider> providerList, 
                           PermissionMapper permissionMapper, AttributeMapper<String> authorityMapper) {
         super(nv, modifyAttributeList);
         this.metaDataList = metaDataList;
         this.deleteMetaDataList = deleteMetaDataList;
         this.permissionMapper = permissionMapper;
         this.authorityMapper = authorityMapper;
+        this.providerList = providerList;
     }
 
     @Override
     public NodeVisitor child(String ns, String name) {
+        System.out.println(" ManifestTagVisitor child  --> ns = " + ns + " name = " + name);
         if (META_DATA_FLAG.equals(ns)) {
             NodeVisitor nv = super.child(null, name);
             if (curMetaData != null) {
@@ -57,11 +61,26 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
         curMetaData = null;
     }
 
+     public static String getStackTrace(Throwable t){
+        StringBuilder sb = new StringBuilder();
+        for(StackTraceElement element : t.getStackTrace()){
+            sb.append(element.toString());
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
     @Override
     public void end() {
         if (metaDataList != null) {
             for (ModificationProperty.MetaData data : metaDataList) {
                 addChild(data);
+            }
+        }
+        if (providerList != null) {
+            for (ModificationProperty.Provider provider : providerList) {
+                NodeVisitor nv = super.child(null, "provider");
+                new ProviderVisitor(nv, provider);
             }
         }
         super.end();

--- a/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
@@ -24,7 +24,6 @@ public class ManifestTagVisitor extends ModifyAttributeVisitor {
 
     @Override
     public NodeVisitor child(String ns, String name) {
-        Log.d(" ManifestTagVisitor child  --> ns = " + ns + " name = " + name);
 
         if (ns != null && (NodeValue.UsesPermission.TAG_NAME).equals(name)) {
             NodeVisitor child = super.child(null, NodeValue.UsesPermission.TAG_NAME);
@@ -35,7 +34,7 @@ public class ManifestTagVisitor extends ModifyAttributeVisitor {
         if (NodeValue.Application.TAG_NAME.equals(name)) {
             return new ApplicationTagVisitor(child, properties.getApplicationAttributeList(),
                     properties.getMetaDataList(), properties.getDeleteMetaDataList(),
-                    properties.getPermissionMapper(), properties.getAuthorityMapper());
+                    properties.getPermissionMapper(), properties.getAuthorityMapper(), properties.getProviderList());
         }
 
         if (NodeValue.UsesSDK.TAG_NAME.equals(name)) {

--- a/lib/src/main/java/com/wind/meditor/visitor/ModifyAttributeVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ModifyAttributeVisitor.java
@@ -4,6 +4,7 @@ import com.wind.meditor.property.AttributeItem;
 import com.wind.meditor.utils.Utils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import pxb.android.axml.NodeVisitor;

--- a/lib/src/main/java/com/wind/meditor/visitor/ProviderVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ProviderVisitor.java
@@ -14,7 +14,10 @@ public class ProviderVisitor extends ModifyAttributeVisitor{
 
         NodeVisitor intentFilter = super.child(null, "intent-filter");
         NodeVisitor action = intentFilter.child(null, "action");
-        action.attr(null, "name", -1, NodeVisitor.TYPE_STRING, provider.getFilterNameValue());
+
+        List<AttributeItem> list = new ArrayList<>();
+        list.add(new AttributeItem("name", provider.getFilterNameValue()));
+        new ModifyAttributeVisitor(action, list,true);
     }
 
     private static List<AttributeItem> convertToAttr(ModificationProperty.Provider provider) {
@@ -23,7 +26,7 @@ public class ProviderVisitor extends ModifyAttributeVisitor{
         }
         ArrayList<AttributeItem> list = new ArrayList<>();
         for (String keys : provider.getNameValue().keySet()){
-            list.add(new AttributeItem(keys, provider.getNameValue().get(keys)));
+           list.add(new AttributeItem(keys, provider.getNameValue().get(keys)));
         }
         return list;
     }

--- a/lib/src/main/java/com/wind/meditor/visitor/ProviderVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ProviderVisitor.java
@@ -1,0 +1,30 @@
+package com.wind.meditor.visitor;
+
+import com.wind.meditor.property.AttributeItem;
+import com.wind.meditor.property.ModificationProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import pxb.android.axml.NodeVisitor;
+
+public class ProviderVisitor extends ModifyAttributeVisitor{
+    ProviderVisitor(NodeVisitor nv, ModificationProperty.Provider provider) {
+        super(nv, convertToAttr(provider), true);
+
+        NodeVisitor intentFilter = super.child(null, "intent-filter");
+        NodeVisitor action = intentFilter.child(null, "action");
+        action.attr(null, "name", -1, NodeVisitor.TYPE_STRING, provider.getFilterNameValue());
+    }
+
+    private static List<AttributeItem> convertToAttr(ModificationProperty.Provider provider) {
+        if (provider == null) {
+            return null;
+        }
+        ArrayList<AttributeItem> list = new ArrayList<>();
+        for (String keys : provider.getNameValue().keySet()){
+            list.add(new AttributeItem(keys, provider.getNameValue().get(keys)));
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
 允许用户通过 ModificationProperty.addProvider() API 在 Manifest 文件中动态插入 <provider> 节点，并同时配置其内部的 <intent-filter> 和 <action> 子节点。

新增 ProviderVisitor，专用于处理和构建 provider 及其子标签（intent-filter 和 action）的逻辑。
修改了 ApplicationTagVisitor 的构造函数和 end() 方法，使其能够接收并遍历待添加的 Provider 列表，实现节点的插入。
修复了可能导致生成的 APK 文件无效的潜在构建问题。

使用实例:
[NPatch](github.com/7723Mod/NPatch)