### PR TITLE
# Activity节点添加功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ options:
                              ld be separated by : , if name is in android namesp
                              ace, prefix "android-" should be set, multi option 
                              is supported
+ -act,--activity <activity-config>
+                             add/replace activity, format: activity-name[:exported]
+                             , supports true/false or 1/0 for exported
+                             , multi option is supported
  -an,--applicationName <new-application-name>
                              set the app entry application name
  -d,--debuggable <0 or 1>    set 1 to make the app debuggable = true, set 0 to m
@@ -150,6 +154,18 @@ $ java -jar ../ManifestEditor.jar ../AndroidManifest.xml -dmd xposedminversion -
          <meta-data />
 ```
 通过删除和新增两个操作可以实现对某个指定的`<meta-data/>`的修改。
+
+### 11. 新增Activity节点: `-act`
+```
+$ java -jar ../ManifestEditor.jar ../AndroidManifest.xml -act com.example.NewActivity
+```
+添加带exported属性的Activity：
+```
+$ java -jar ../ManifestEditor.jar ../AndroidManifest.xml -act com.example.LoginActivity:true
+```
+参数格式：`activity-name[:exported]`
+
+**注意**：目前Activity功能已简化，仅支持name和exported属性。如果需要更复杂的Activity配置，请使用其他工具或直接编辑Manifest文件。
 # **修改Apk中的Manifest文件**
 ```
 $ java -jar ../ManifestEditor.jar ../original.apk -o ../new_build_unsigned.apk -d 1

--- a/lib/src/main/java/com/wind/meditor/ManifestEditorMain.java
+++ b/lib/src/main/java/com/wind/meditor/ManifestEditorMain.java
@@ -87,6 +87,12 @@ public class ManifestEditorMain extends BaseCommand {
             ", multi option is supported", argName = "delete-meta-data-name")
     private List<String> deleteMetaDataList = new ArrayList<>();
 
+    @Opt(opt = "act", longOpt = "activity", description = "add new activity or replace existing activity, " +
+            "format: activity-name[:exported]" +
+            ", supports true/false or 1/0 for exported" +
+            ", multi option is supported", argName = "activity-config")
+    private List<String> activityList = new ArrayList<>();
+
     public static void main(String... args) {
         new ManifestEditorMain().doMain(args);
     }
@@ -272,6 +278,17 @@ public class ManifestEditorMain extends BaseCommand {
 
         for (String metaData : deleteMetaDataList) {
             property.addDeleteMetaData(metaData);
+        }
+
+        for (String activityConfig : activityList) {
+            String[] parts = activityConfig.split(":");
+            if (parts.length >= 1) {
+                ModificationProperty.Activity activity = new ModificationProperty.Activity(parts[0]);
+                if (parts.length >= 2 && !parts[1].isEmpty()) {
+                    activity.setExported("true".equalsIgnoreCase(parts[1]) || "1".equals(parts[1]));
+                }
+                property.addActivity(activity);
+            }
         }
 
 //        property.addManifestAttribute(new AttributeItem(NodeValue.Manifest.PACKAGE, "wind.new.pkg.name111").setNamespace(null))

--- a/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
+++ b/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
@@ -18,6 +18,7 @@ public class ModificationProperty {
     private List<AttributeItem> applicationAttributeList = new ArrayList<>();
     private List<AttributeItem> manifestAttributeList = new ArrayList<>();
     private List<AttributeItem> usesSdkAttributeList = new ArrayList<>();
+    private List<Activity> activityList = new ArrayList<>();
 
     private PermissionMapper permissionMapper;
     private AttributeMapper<String> providerAuthorityMapper;
@@ -43,6 +44,11 @@ public class ModificationProperty {
 
     public ModificationProperty addProvider(HashMap<String,String> nameValue,String filterNameValue){
         providerList.add(new Provider(nameValue,filterNameValue));
+        return this;
+    }
+
+    public ModificationProperty addActivity(Activity activity) {
+        activityList.add(activity);
         return this;
     }
 
@@ -79,6 +85,10 @@ public class ModificationProperty {
 
     public List<Provider> getProviderList(){
         return providerList;
+    }
+
+    public List<Activity> getActivityList() {
+        return activityList;
     }
 
     public ModificationProperty addDeleteMetaData(String name) {
@@ -138,6 +148,32 @@ public class ModificationProperty {
         }
         public String getFilterNameValue(){
             return filterNameValue;
+        }
+    }
+
+    public static class Activity {
+        private String name;
+        private Boolean exported;
+
+
+        public Activity(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Boolean getExported() {
+            return exported;
+        }
+
+        public void setExported(Boolean exported) {
+            this.exported = exported;
         }
     }
 }

--- a/lib/src/main/java/com/wind/meditor/visitor/ActivityTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ActivityTagVisitor.java
@@ -1,0 +1,175 @@
+package com.wind.meditor.visitor;
+
+import com.wind.meditor.property.ModificationProperty;
+import com.wind.meditor.utils.Log;
+
+import java.util.Map;
+
+import pxb.android.axml.NodeVisitor;
+
+/**
+ * 处理Activity节点的访问者类
+ * 负责在AndroidManifest.xml中添加新的Activity节点或替换现有Activity节点
+ */
+public class ActivityTagVisitor extends NodeVisitor {
+
+    private ModificationProperty.Activity activity;
+    private boolean activityAdded = false;
+    private boolean isReplacementMode = false;
+    private String existingActivityName = null;
+    private boolean activityReplaced = false;
+    private Map<String, ModificationProperty.Activity> activityReplacementMap;
+    private boolean nameChecked = false;
+
+    // 构造函数1：用于添加新Activity
+    public ActivityTagVisitor(NodeVisitor nv, ModificationProperty.Activity activity) {
+        super(nv);
+        this.activity = activity;
+        this.isReplacementMode = false;
+    }
+
+    // 构造函数2：用于替换现有Activity
+    public ActivityTagVisitor(NodeVisitor nv, Map<String, ModificationProperty.Activity> activityReplacementMap) {
+        super(nv);
+        this.activityReplacementMap = activityReplacementMap;
+        this.isReplacementMode = true;
+    }
+
+    @Override
+    public void attr(String ns, String name, int resourceId, int type, Object obj) {
+        if (isReplacementMode) {
+            handleReplacementAttribute(ns, name, resourceId, type, obj);
+        } else {
+            super.attr(ns, name, resourceId, type, obj);
+        }
+    }
+
+    private void handleReplacementAttribute(String ns, String name, int resourceId, int type, Object obj) {
+        // 首次遇到name属性时检查是否需要替换
+        if (!nameChecked && "name".equals(name) && obj instanceof String) {
+            existingActivityName = (String) obj;
+            ModificationProperty.Activity replacementActivity = activityReplacementMap.get(existingActivityName);
+            if (replacementActivity != null) {
+                this.activity = replacementActivity;
+                activityReplacementMap.remove(existingActivityName);
+                nameChecked = true;
+            }
+        }
+
+        // 检查是否为目标Activity
+        boolean isTarget = isTargetActivity();
+        // 如果是同名Activity，则替换属性
+        boolean shouldReplace = shouldReplaceAttribute(name);
+        if (shouldReplace) {
+            Object newValue = getNewAttributeValue(name);
+            if (newValue != null) {
+                super.attr(ns, name, resourceId, type, newValue);
+                activityReplaced = true;
+                return;
+            }
+        }
+
+        // 保留原有属性（只有在不需要替换时才保留）
+        // 注意：这里不能无条件调用super.attr，否则会覆盖已设置的新值
+        if (!shouldReplaceAttribute(name)) {
+            super.attr(ns, name, resourceId, type, obj);
+        }
+    }
+
+    @Override
+    public NodeVisitor child(String ns, String name) {
+        NodeVisitor child = super.child(ns, name);
+        return child;
+    }
+
+    @Override
+    public void end() {
+        if (isReplacementMode) {
+            // 如果还没有替换任何属性，且是目标Activity，则添加缺失的属性
+            if (!activityReplaced && isTargetActivity()) {
+                addMissingAttributes();
+            }
+        } else {
+            if (!activityAdded) {
+                setActivityAttributes();
+            }
+        }
+        super.end();
+    }
+
+    /**
+     * 判断是否应该替换指定属性
+     */
+    private boolean shouldReplaceAttribute(String attributeName) {
+        boolean isTarget = isTargetActivity();
+        if (!isTarget) {
+            return false;
+        }
+        
+        // 目前只支持替换exported属性
+        if ("exported".equals(attributeName)) {
+            boolean shouldReplace = activity != null && activity.getExported() != null;
+            return shouldReplace;
+        }
+        
+        return false;
+    }
+
+    /**
+     * 获取新属性值
+     */
+    private Object getNewAttributeValue(String attributeName) {
+        if (activity == null) return null;
+        
+        if ("exported".equals(attributeName)) {
+            return activity.getExported() ? 1 : 0; // 1表示true，0表示false
+        }
+        
+        return null;
+    }
+
+    /**
+     * 判断是否为目标Activity（同名）
+     */
+    private boolean isTargetActivity() {
+        return existingActivityName != null &&
+               activity != null &&
+               existingActivityName.equals(activity.getName());
+    }
+
+    /**
+     * 添加新Activity中有但原Activity中没有的属性
+     */
+    private void addMissingAttributes() {
+        if (activity == null) return;
+
+        // 添加缺失的exported属性
+        if (activity.getExported() != null) {
+            super.attr("http://schemas.android.com/apk/res/android", "exported",
+                0x01010010, // android:exported resource id
+                18, activity.getExported() ? 1 : 0);
+        }
+    }
+
+    /**
+     * 设置Activity的基本属性（用于添加新模式）
+     */
+    private void setActivityAttributes() {
+        if (activity == null || activity.getName() == null) {
+            return;
+        }
+
+        // 设置android:name属性
+        super.attr("http://schemas.android.com/apk/res/android", "name", 
+            0x01010003, // android:name resource id
+            3, activity.getName()); // 3 represents TYPE_STRING
+
+        // 设置android:exported属性
+        if (activity.getExported() != null) {
+            super.attr("http://schemas.android.com/apk/res/android", "exported",
+                0x01010010, // android:exported resource id
+                18, activity.getExported() ? 1 : 0); // 18 represents TYPE_INT_BOOLEAN
+        }
+        activityAdded = true;
+    }
+}

--- a/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
@@ -6,7 +6,10 @@ import com.wind.meditor.property.ModificationProperty;
 import com.wind.meditor.property.PermissionMapper;
 import com.wind.meditor.utils.NodeValue;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import pxb.android.axml.NodeVisitor;
 
 /**
@@ -18,8 +21,10 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
     private List<ModificationProperty.MetaData> metaDataList;
     private List<ModificationProperty.MetaData> deleteMetaDataList;
     private List<ModificationProperty.Provider> providerList;
+    private List<ModificationProperty.Activity> activityList;
     private PermissionMapper permissionMapper;
     private AttributeMapper<String> authorityMapper;
+    private Map<String, ModificationProperty.Activity> activityReplacementMap;
 
     private static final String META_DATA_FLAG = "meta_data_flag";
 
@@ -28,13 +33,21 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
                           List<ModificationProperty.MetaData> deleteMetaDataList,
                           PermissionMapper permissionMapper,
                           AttributeMapper<String> authorityMapper,
-                          List<ModificationProperty.Provider> providerList) {
+                          List<ModificationProperty.Provider> providerList,
+                          List<ModificationProperty.Activity> activityList) {
         super(nv, modifyAttributeList);
         this.metaDataList = metaDataList;
         this.deleteMetaDataList = deleteMetaDataList;
         this.permissionMapper = permissionMapper;
         this.authorityMapper = authorityMapper;
-        this.providerList = providerList; // 儲存 providerList
+        this.providerList = providerList;
+        this.activityList = activityList;
+        this.activityReplacementMap = new HashMap<>();
+        if (activityList != null) {
+            for (ModificationProperty.Activity activity : activityList) {
+                activityReplacementMap.put(activity.getName(), activity);
+            }
+        }
     }
 
     @Override
@@ -51,7 +64,11 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
             NodeVisitor nv = super.child(ns, name);
             return new DeleteMetaDataVisitor(nv, deleteMetaDataList);
         } else if (NodeValue.Application.COMPONENT_TAGS.contains(name)) {
-            return new ApplicationComponentTagVisitor(super.child(ns, name), permissionMapper, authorityMapper);
+            NodeVisitor nv = super.child(ns, name);
+            if (NodeValue.Application.Activity.TAG_NAME.equals(name)) {
+                return new ActivityTagVisitor(nv, activityReplacementMap);
+            }
+            return new ApplicationComponentTagVisitor(nv, permissionMapper, authorityMapper);
         }
         return super.child(ns, name);
     }
@@ -82,6 +99,15 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
             for (ModificationProperty.Provider provider : providerList) {
                 NodeVisitor nv = super.child(null, "provider");
                 new ProviderVisitor(nv, provider);
+            }
+        }
+        if (!activityReplacementMap.isEmpty()) {
+            for (ModificationProperty.Activity activity : activityReplacementMap.values()) {
+                NodeVisitor nv = super.child(null, "activity");
+                if (nv != null) {
+                    ActivityTagVisitor activityVisitor = new ActivityTagVisitor(nv, activity);
+                    activityVisitor.end();
+                }
             }
         }
         super.end();

--- a/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
@@ -34,7 +34,8 @@ public class ManifestTagVisitor extends ModifyAttributeVisitor {
         if (NodeValue.Application.TAG_NAME.equals(name)) {
             return new ApplicationTagVisitor(child, properties.getApplicationAttributeList(),
                     properties.getMetaDataList(), properties.getDeleteMetaDataList(),
-                    properties.getPermissionMapper(), properties.getAuthorityMapper(), properties.getProviderList());
+                    properties.getPermissionMapper(), properties.getAuthorityMapper(), 
+                    properties.getProviderList(), properties.getActivityList());
         }
 
         if (NodeValue.UsesSDK.TAG_NAME.equals(name)) {


### PR DESCRIPTION
## 功能概述

本项目支持向AndroidManifest.xml文件中添加新的Activity节点。该功能允许用户通过两种方式动态地向应用清单文件中插入Activity声明：

1. **命令行方式**：通过参数直接添加Activity
2. **编程方式**：通过Java API在代码中添加Activity

### 当前支持的属性

目前Activity功能仅支持以下两个基本属性：
- **name**：Activity的完整类名（必需）
- **exported**：是否可被外部应用启动（可选，布尔值）

## 新增功能组件

### 1. 数据模型扩展

在 `ModificationProperty.java` 中新增了以下类：

#### Activity 类
```java
public static class Activity {
    private String name;
    private Boolean exported;
    // ... getter/setter方法
}
```

### 2. 访问者模式实现

创建了以下类来处理Activity节点的XML生成：

#### ActivityTagVisitor.java
- 继承自 `NodeVisitor`
- 负责创建新的Activity节点
- 支持name和exported属性
- 内置智能替换机制，避免重复Activity声明

### 3. 核心流程修改

#### ApplicationTagVisitor 修改
- 在 `child()` 方法中实现了Activity节点处理逻辑
- 内置同名Activity检测机制
- 自动处理Activity替换和新增的区分
- 在 `end()` 方法中处理剩余的新增Activity

#### ManifestTagVisitor 修改
- 更新构造函数以传递Activity列表参数

### 4. 编程接口

提供了完整的Java API供开发者直接在代码中使用：

```java
// 创建ModificationProperty实例
ModificationProperty property = new ModificationProperty();

// 创建Activity对象
ModificationProperty.Activity activity = new ModificationProperty.Activity("com.test.NewActivity");
activity.setExported(true);

// 添加到属性中
property.addActivity(activity);

// 处理APK文件
FileProcesser.processApkFile(inputApkFilePath, outputApkFilePath, property);
```

#### 调试支持
添加了详细的调试日志输出：
```java
// 查看准备添加的Activity信息
System.out.println("准备添加Activity数量: " + property.getActivityList().size());
for (ModificationProperty.Activity act : property.getActivityList()) {
    System.out.println("Activity名称: " + act.getName());
    System.out.println("Activity exported: " + act.getExported());
}
```

## 命令行接口扩展

新增了三个命令行参数：

### `-act` 或 `--activity`
添加新的Activity节点

**格式：** `activity-name[:exported]`

**示例：**
```bash
# 简单Activity
java -jar ManifestEditor.jar app.apk -act com.example.NewActivity

# 带exported属性的Activity
java -jar ManifestEditor.jar app.apk -act com.example.LoginActivity:true
```

## 使用示例

### 使用示例

```bash
# 添加简单的Activity
java -jar ManifestEditor.jar app.apk -act com.example.NewActivity

# 添加带exported属性的Activity
java -jar ManifestEditor.jar app.apk -act com.example.LoginActivity:true

# 添加多个Activity
java -jar ManifestEditor.jar app.apk \
  -act com.example.SplashActivity:true \
  -act com.example.MainActivity:false \
  -act com.example.SettingsActivity:true
```

## 技术实现细节

### 属性资源ID映射
ActivityTagVisitor中使用了标准的Android属性资源ID：
- `name`: 0x01010003
- `exported`: 0x01010010

### XML生成流程
1. ApplicationTagVisitor检测到Activity列表不为空
2. 为每个Activity创建child节点"activity"
3. ActivityTagVisitor负责设置具体的属性值
4. **关键步骤**：必须调用ActivityTagVisitor的`end()`方法来触发属性设置
5. 最终生成完整的Activity XML节点

### 常见问题排查

如果Activity添加不成功，请检查：
1. **确保调用end()方法**：ActivityTagVisitor必须显式调用`end()`方法
2. **验证输入文件**：确认APK文件路径正确且文件存在
3. **检查输出权限**：确保输出路径有写入权限
4. **查看调试日志**：启用详细日志输出来跟踪执行过程
5. **验证Activity配置**：确保Activity名称不为空

## 注意事项

### 命令行使用注意事项
1. **命名空间**：Activity属性使用Android命名空间 `http://schemas.android.com/apk/res/android`
2. **布尔值表示**：exported属性接受"true"/"false"或"1"/"0"
3. **必需参数**：Activity名称是必需的
4. **可选参数**：exported属性是可选的
5. **重复检测**：同名Activity会自动替换，避免重复声明

### 编程使用注意事项
1. **对象生命周期**：确保Activity对象在添加后不被修改
2. **属性验证**：Activity名称不能为空
3. **方法调用顺序**：先设置属性再添加到ModificationProperty中
4. **调试建议**：使用提供的调试日志方法验证配置