### PR TITLE
feat: refine activity replace flow and support provider deletion by authorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,17 +155,17 @@ $ java -jar ../ManifestEditor.jar ../AndroidManifest.xml -dmd xposedminversion -
 ```
 通过删除和新增两个操作可以实现对某个指定的`<meta-data/>`的修改。
 
-### 11. 新增Activity节点: `-act`
+### 11. 新增或替换Activity节点: `-act`
 ```
 $ java -jar ../ManifestEditor.jar ../AndroidManifest.xml -act com.example.NewActivity
 ```
-添加带exported属性的Activity：
+如果需要同时设置 `android:exported`，可以直接在名称后面附上布尔值或 `1/0`：
 ```
 $ java -jar ../ManifestEditor.jar ../AndroidManifest.xml -act com.example.LoginActivity:true
 ```
 参数格式：`activity-name[:exported]`
 
-**注意**：目前Activity功能已简化，仅支持name和exported属性。如果需要更复杂的Activity配置，请使用其他工具或直接编辑Manifest文件。
+**说明**：`-act` 目前只处理 `name` 和 `exported` 两个属性。新增时会写入这两个必要字段；若同名 Activity 已存在，则只更新当前支持的属性，不会扩展其他复杂配置。
 # **修改Apk中的Manifest文件**
 ```
 $ java -jar ../ManifestEditor.jar ../original.apk -o ../new_build_unsigned.apk -d 1

--- a/lib/src/main/java/com/wind/meditor/ManifestEditorMain.java
+++ b/lib/src/main/java/com/wind/meditor/ManifestEditorMain.java
@@ -87,10 +87,9 @@ public class ManifestEditorMain extends BaseCommand {
             ", multi option is supported", argName = "delete-meta-data-name")
     private List<String> deleteMetaDataList = new ArrayList<>();
 
-    @Opt(opt = "act", longOpt = "activity", description = "add new activity or replace existing activity, " +
-            "format: activity-name[:exported]" +
-            ", supports true/false or 1/0 for exported" +
-            ", multi option is supported", argName = "activity-config")
+    @Opt(opt = "act", longOpt = "activity", description = "add or replace an activity node, " +
+            "format: activity-name[:exported], supports true/false or 1/0 for exported, " +
+            "multi option is supported", argName = "activity-config")
     private List<String> activityList = new ArrayList<>();
 
     public static void main(String... args) {
@@ -280,12 +279,12 @@ public class ManifestEditorMain extends BaseCommand {
             property.addDeleteMetaData(metaData);
         }
 
-        for (String activityConfig : activityList) {
-            String[] parts = activityConfig.split(":");
-            if (parts.length >= 1) {
-                ModificationProperty.Activity activity = new ModificationProperty.Activity(parts[0]);
-                if (parts.length >= 2 && !parts[1].isEmpty()) {
-                    activity.setExported("true".equalsIgnoreCase(parts[1]) || "1".equals(parts[1]));
+        for (String activityConfigItem : activityList) {
+            String[] activityParts = activityConfigItem.split(":");
+            if (activityParts.length >= 1) {
+                ModificationProperty.Activity activity = new ModificationProperty.Activity(activityParts[0]);
+                if (activityParts.length >= 2 && !activityParts[1].isEmpty()) {
+                    activity.setExported("true".equalsIgnoreCase(activityParts[1]) || "1".equals(activityParts[1]));
                 }
                 property.addActivity(activity);
             }

--- a/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
+++ b/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
@@ -155,7 +155,6 @@ public class ModificationProperty {
         private String name;
         private Boolean exported;
 
-
         public Activity(String name) {
             this.name = name;
         }

--- a/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
+++ b/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
@@ -23,6 +23,7 @@ public class ModificationProperty {
     private PermissionMapper permissionMapper;
     private AttributeMapper<String> providerAuthorityMapper;
     private List<Provider> providerList = new ArrayList<>();
+    private List<String> deleteProviderAuthorities = new ArrayList<>();
 
     public List<String> getUsesPermissionList() {
         return usesPermissionList;
@@ -85,6 +86,15 @@ public class ModificationProperty {
 
     public List<Provider> getProviderList(){
         return providerList;
+    }
+
+    public List<String> getDeleteProviderAuthorities() {
+        return deleteProviderAuthorities;
+    }
+
+    public ModificationProperty addDeleteProviderAuthorities(String authorities) {
+        deleteProviderAuthorities.add(authorities);
+        return this;
     }
 
     public List<Activity> getActivityList() {

--- a/lib/src/main/java/com/wind/meditor/visitor/ActivityTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ActivityTagVisitor.java
@@ -1,43 +1,41 @@
 package com.wind.meditor.visitor;
 
 import com.wind.meditor.property.ModificationProperty;
-import com.wind.meditor.utils.Log;
 
 import java.util.Map;
 
 import pxb.android.axml.NodeVisitor;
 
 /**
- * 处理Activity节点的访问者类
- * 负责在AndroidManifest.xml中添加新的Activity节点或替换现有Activity节点
+ * Handles Activity nodes in AndroidManifest.xml.
  */
 public class ActivityTagVisitor extends NodeVisitor {
 
-    private ModificationProperty.Activity activity;
-    private boolean activityAdded = false;
-    private boolean isReplacementMode = false;
-    private String existingActivityName = null;
-    private boolean activityReplaced = false;
-    private Map<String, ModificationProperty.Activity> activityReplacementMap;
-    private boolean nameChecked = false;
+    private ModificationProperty.Activity targetActivity;
+    private boolean activityWritten = false;
+    private boolean replaceExistingActivity = false;
+    private String currentActivityName = null;
+    private boolean replacementApplied = false;
+    private Map<String, ModificationProperty.Activity> replacementActivities;
+    private boolean nameResolved = false;
 
-    // 构造函数1：用于添加新Activity
+    // Creates a visitor for adding a new Activity.
     public ActivityTagVisitor(NodeVisitor nv, ModificationProperty.Activity activity) {
         super(nv);
-        this.activity = activity;
-        this.isReplacementMode = false;
+        this.targetActivity = activity;
+        this.replaceExistingActivity = false;
     }
 
-    // 构造函数2：用于替换现有Activity
+    // Creates a visitor for replacing an existing Activity.
     public ActivityTagVisitor(NodeVisitor nv, Map<String, ModificationProperty.Activity> activityReplacementMap) {
         super(nv);
-        this.activityReplacementMap = activityReplacementMap;
-        this.isReplacementMode = true;
+        this.replacementActivities = activityReplacementMap;
+        this.replaceExistingActivity = true;
     }
 
     @Override
     public void attr(String ns, String name, int resourceId, int type, Object obj) {
-        if (isReplacementMode) {
+        if (replaceExistingActivity) {
             handleReplacementAttribute(ns, name, resourceId, type, obj);
         } else {
             super.attr(ns, name, resourceId, type, obj);
@@ -45,131 +43,111 @@ public class ActivityTagVisitor extends NodeVisitor {
     }
 
     private void handleReplacementAttribute(String ns, String name, int resourceId, int type, Object obj) {
-        // 首次遇到name属性时检查是否需要替换
-        if (!nameChecked && "name".equals(name) && obj instanceof String) {
-            existingActivityName = (String) obj;
-            ModificationProperty.Activity replacementActivity = activityReplacementMap.get(existingActivityName);
+        if (!nameResolved && "name".equals(name) && obj instanceof String) {
+            currentActivityName = (String) obj;
+            ModificationProperty.Activity replacementActivity = replacementActivities.get(currentActivityName);
             if (replacementActivity != null) {
-                this.activity = replacementActivity;
-                activityReplacementMap.remove(existingActivityName);
-                nameChecked = true;
+                targetActivity = replacementActivity;
+                replacementActivities.remove(currentActivityName);
+                nameResolved = true;
             }
         }
 
-        // 检查是否为目标Activity
-        boolean isTarget = isTargetActivity();
-        // 如果是同名Activity，则替换属性
-        boolean shouldReplace = shouldReplaceAttribute(name);
-        if (shouldReplace) {
+        if (shouldReplaceAttribute(name)) {
             Object newValue = getNewAttributeValue(name);
             if (newValue != null) {
                 super.attr(ns, name, resourceId, type, newValue);
-                activityReplaced = true;
+                replacementApplied = true;
                 return;
             }
         }
 
-        // 保留原有属性（只有在不需要替换时才保留）
-        // 注意：这里不能无条件调用super.attr，否则会覆盖已设置的新值
-        if (!shouldReplaceAttribute(name)) {
-            super.attr(ns, name, resourceId, type, obj);
-        }
-    }
-
-    @Override
-    public NodeVisitor child(String ns, String name) {
-        NodeVisitor child = super.child(ns, name);
-        return child;
+        super.attr(ns, name, resourceId, type, obj);
     }
 
     @Override
     public void end() {
-        if (isReplacementMode) {
-            // 如果还没有替换任何属性，且是目标Activity，则添加缺失的属性
-            if (!activityReplaced && isTargetActivity()) {
+        if (replaceExistingActivity) {
+            if (!replacementApplied && isTargetActivity()) {
                 addMissingAttributes();
             }
-        } else {
-            if (!activityAdded) {
-                setActivityAttributes();
-            }
+        } else if (!activityWritten) {
+            setActivityAttributes();
         }
         super.end();
     }
 
     /**
-     * 判断是否应该替换指定属性
+     * Returns true when the given attribute should be replaced.
      */
     private boolean shouldReplaceAttribute(String attributeName) {
-        boolean isTarget = isTargetActivity();
-        if (!isTarget) {
+        if (!isTargetActivity()) {
             return false;
         }
-        
-        // 目前只支持替换exported属性
+
         if ("exported".equals(attributeName)) {
-            boolean shouldReplace = activity != null && activity.getExported() != null;
-            return shouldReplace;
+            return targetActivity != null && targetActivity.getExported() != null;
         }
-        
+
         return false;
     }
 
     /**
-     * 获取新属性值
+     * Returns the replacement value for the given attribute.
      */
     private Object getNewAttributeValue(String attributeName) {
-        if (activity == null) return null;
-        
-        if ("exported".equals(attributeName)) {
-            return activity.getExported() ? 1 : 0; // 1表示true，0表示false
+        if (targetActivity == null) {
+            return null;
         }
-        
+
+        if ("exported".equals(attributeName)) {
+            return targetActivity.getExported() ? 1 : 0;
+        }
+
         return null;
     }
 
     /**
-     * 判断是否为目标Activity（同名）
+     * Returns true when the current node matches the target Activity.
      */
     private boolean isTargetActivity() {
-        return existingActivityName != null &&
-               activity != null &&
-               existingActivityName.equals(activity.getName());
+        return currentActivityName != null &&
+               targetActivity != null &&
+               currentActivityName.equals(targetActivity.getName());
     }
 
     /**
-     * 添加新Activity中有但原Activity中没有的属性
+     * Adds attributes that exist on the new Activity but are missing on the current one.
      */
     private void addMissingAttributes() {
-        if (activity == null) return;
-
-        // 添加缺失的exported属性
-        if (activity.getExported() != null) {
-            super.attr("http://schemas.android.com/apk/res/android", "exported",
-                0x01010010, // android:exported resource id
-                18, activity.getExported() ? 1 : 0);
-        }
-    }
-
-    /**
-     * 设置Activity的基本属性（用于添加新模式）
-     */
-    private void setActivityAttributes() {
-        if (activity == null || activity.getName() == null) {
+        if (targetActivity == null) {
             return;
         }
 
-        // 设置android:name属性
-        super.attr("http://schemas.android.com/apk/res/android", "name", 
-            0x01010003, // android:name resource id
-            3, activity.getName()); // 3 represents TYPE_STRING
-
-        // 设置android:exported属性
-        if (activity.getExported() != null) {
+        if (targetActivity.getExported() != null) {
             super.attr("http://schemas.android.com/apk/res/android", "exported",
-                0x01010010, // android:exported resource id
-                18, activity.getExported() ? 1 : 0); // 18 represents TYPE_INT_BOOLEAN
+                0x01010010,
+                18, targetActivity.getExported() ? 1 : 0);
         }
-        activityAdded = true;
+    }
+
+    /**
+     * Writes the base Activity attributes for a newly added node.
+     */
+    private void setActivityAttributes() {
+        if (targetActivity == null || targetActivity.getName() == null) {
+            return;
+        }
+
+        super.attr("http://schemas.android.com/apk/res/android", "name",
+            0x01010003,
+            3, targetActivity.getName());
+
+        if (targetActivity.getExported() != null) {
+            super.attr("http://schemas.android.com/apk/res/android", "exported",
+                0x01010010,
+                18, targetActivity.getExported() ? 1 : 0);
+        }
+        activityWritten = true;
     }
 }

--- a/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
@@ -25,8 +25,13 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
     private PermissionMapper permissionMapper;
     private AttributeMapper<String> authorityMapper;
     private Map<String, ModificationProperty.Activity> pendingActivitiesByName;
+    private List<String> deleteProviderAuthorities;
 
     private static final String META_DATA_FLAG = "meta_data_flag";
+
+    void setDeleteProviderAuthorities(List<String> deleteProviderAuthorities) {
+        this.deleteProviderAuthorities = deleteProviderAuthorities;
+    }
 
     ApplicationTagVisitor(NodeVisitor nv, List<AttributeItem> modifyAttributeList,
                           List<ModificationProperty.MetaData> metaDataList,
@@ -64,6 +69,10 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
             NodeVisitor nv = super.child(ns, name);
             return new DeleteMetaDataVisitor(nv, deleteMetaDataList);
         } else if (NodeValue.Application.COMPONENT_TAGS.contains(name)) {
+            if (NodeValue.Application.Provider.TAG_NAME.equals(name)
+                    && deleteProviderAuthorities != null && !deleteProviderAuthorities.isEmpty()) {
+                return new ProviderDeleteVisitor(this.nv, deleteProviderAuthorities, ns, name);
+            }
             NodeVisitor nv = super.child(ns, name);
             if (NodeValue.Application.Activity.TAG_NAME.equals(name)) {
                 return new ActivityTagVisitor(nv, pendingActivitiesByName);

--- a/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ApplicationTagVisitor.java
@@ -24,7 +24,7 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
     private List<ModificationProperty.Activity> activityList;
     private PermissionMapper permissionMapper;
     private AttributeMapper<String> authorityMapper;
-    private Map<String, ModificationProperty.Activity> activityReplacementMap;
+    private Map<String, ModificationProperty.Activity> pendingActivitiesByName;
 
     private static final String META_DATA_FLAG = "meta_data_flag";
 
@@ -42,10 +42,10 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
         this.authorityMapper = authorityMapper;
         this.providerList = providerList;
         this.activityList = activityList;
-        this.activityReplacementMap = new HashMap<>();
+        this.pendingActivitiesByName = new HashMap<>();
         if (activityList != null) {
             for (ModificationProperty.Activity activity : activityList) {
-                activityReplacementMap.put(activity.getName(), activity);
+                pendingActivitiesByName.put(activity.getName(), activity);
             }
         }
     }
@@ -66,7 +66,7 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
         } else if (NodeValue.Application.COMPONENT_TAGS.contains(name)) {
             NodeVisitor nv = super.child(ns, name);
             if (NodeValue.Application.Activity.TAG_NAME.equals(name)) {
-                return new ActivityTagVisitor(nv, activityReplacementMap);
+                return new ActivityTagVisitor(nv, pendingActivitiesByName);
             }
             return new ApplicationComponentTagVisitor(nv, permissionMapper, authorityMapper);
         }
@@ -101,8 +101,8 @@ public class ApplicationTagVisitor extends ModifyAttributeVisitor {
                 new ProviderVisitor(nv, provider);
             }
         }
-        if (!activityReplacementMap.isEmpty()) {
-            for (ModificationProperty.Activity activity : activityReplacementMap.values()) {
+        if (!pendingActivitiesByName.isEmpty()) {
+            for (ModificationProperty.Activity activity : pendingActivitiesByName.values()) {
                 NodeVisitor nv = super.child(null, "activity");
                 if (nv != null) {
                     ActivityTagVisitor activityVisitor = new ActivityTagVisitor(nv, activity);

--- a/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
@@ -11,7 +11,7 @@ import pxb.android.axml.NodeVisitor;
 
 public class ManifestTagVisitor extends ModifyAttributeVisitor {
 
-    private ModificationProperty properties;
+    private ModificationProperty modificationProperty;
 
     private List<String> hasIncludedUsesPermissionList = new ArrayList<>();
 
@@ -19,7 +19,7 @@ public class ManifestTagVisitor extends ModifyAttributeVisitor {
 
     public ManifestTagVisitor(NodeVisitor nv, ModificationProperty properties) {
         super(nv, properties.getManifestAttributeList());
-        this.properties = properties;
+        this.modificationProperty = properties;
     }
 
     @Override
@@ -27,27 +27,27 @@ public class ManifestTagVisitor extends ModifyAttributeVisitor {
 
         if (ns != null && (NodeValue.UsesPermission.TAG_NAME).equals(name)) {
             NodeVisitor child = super.child(null, NodeValue.UsesPermission.TAG_NAME);
-            return new UserPermissionTagVisitor(child, null, ns, properties.getPermissionMapper());
+            return new UserPermissionTagVisitor(child, null, ns, modificationProperty.getPermissionMapper());
         }
 
         NodeVisitor child = super.child(ns, name);
         if (NodeValue.Application.TAG_NAME.equals(name)) {
-            return new ApplicationTagVisitor(child, properties.getApplicationAttributeList(),
-                    properties.getMetaDataList(), properties.getDeleteMetaDataList(),
-                    properties.getPermissionMapper(), properties.getAuthorityMapper(), 
-                    properties.getProviderList(), properties.getActivityList());
+            return new ApplicationTagVisitor(child, modificationProperty.getApplicationAttributeList(),
+                    modificationProperty.getMetaDataList(), modificationProperty.getDeleteMetaDataList(),
+                    modificationProperty.getPermissionMapper(), modificationProperty.getAuthorityMapper(),
+                    modificationProperty.getProviderList(), modificationProperty.getActivityList());
         }
 
         if (NodeValue.UsesSDK.TAG_NAME.equals(name)) {
-            return new ModifyAttributeVisitor(child, properties.getUsesSdkAttributeList());
+            return new ModifyAttributeVisitor(child, modificationProperty.getUsesSdkAttributeList());
         }
 
         if (NodeValue.UsesPermission.TAG_NAME.equals(name)) {
-            return new UserPermissionTagVisitor(child, getUsesPermissionGetter(), null, properties.getPermissionMapper());
+            return new UserPermissionTagVisitor(child, getUsesPermissionGetter(), null, modificationProperty.getPermissionMapper());
         }
 
         if (NodeValue.Permission.TAG_NAME.equals(name)) {
-            return new PermissionTagVisitor(child, properties.getPermissionMapper());
+            return new PermissionTagVisitor(child, modificationProperty.getPermissionMapper());
         }
         return child;
     }
@@ -61,7 +61,7 @@ public class ManifestTagVisitor extends ModifyAttributeVisitor {
 
     @Override
     public void end() {
-        List<String> list = properties.getUsesPermissionList();
+        List<String> list = modificationProperty.getUsesPermissionList();
         if (list != null && list.size() > 0) {
             for (String permissionName : list) {
                 // permission is not added.

--- a/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ManifestTagVisitor.java
@@ -32,10 +32,15 @@ public class ManifestTagVisitor extends ModifyAttributeVisitor {
 
         NodeVisitor child = super.child(ns, name);
         if (NodeValue.Application.TAG_NAME.equals(name)) {
-            return new ApplicationTagVisitor(child, modificationProperty.getApplicationAttributeList(),
+            ApplicationTagVisitor appVisitor = new ApplicationTagVisitor(child, modificationProperty.getApplicationAttributeList(),
                     modificationProperty.getMetaDataList(), modificationProperty.getDeleteMetaDataList(),
                     modificationProperty.getPermissionMapper(), modificationProperty.getAuthorityMapper(),
                     modificationProperty.getProviderList(), modificationProperty.getActivityList());
+            List<String> deleteAuthorities = modificationProperty.getDeleteProviderAuthorities();
+            if (deleteAuthorities != null && !deleteAuthorities.isEmpty()) {
+                appVisitor.setDeleteProviderAuthorities(deleteAuthorities);
+            }
+            return appVisitor;
         }
 
         if (NodeValue.UsesSDK.TAG_NAME.equals(name)) {

--- a/lib/src/main/java/com/wind/meditor/visitor/ProviderDeleteVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ProviderDeleteVisitor.java
@@ -1,0 +1,135 @@
+package com.wind.meditor.visitor;
+
+import com.wind.meditor.utils.NodeValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import pxb.android.axml.NodeVisitor;
+
+class ProviderDeleteVisitor extends NodeVisitor {
+
+    private final NodeVisitor parentWriter;
+    private final List<String> deleteAuthorities;
+    private final String elementNs;
+    private final String elementName;
+
+    private final List<AttrRecord> pendingAttrs = new ArrayList<>();
+
+    private NodeVisitor writerNode;
+    private boolean shouldDelete;
+    private boolean decided;
+    private int lineNumber = -1;
+
+    private static class AttrRecord {
+        final String ns;
+        final String name;
+        final int resourceId;
+        final int type;
+        final Object obj;
+
+        AttrRecord(String ns, String name, int resourceId, int type, Object obj) {
+            this.ns = ns;
+            this.name = name;
+            this.resourceId = resourceId;
+            this.type = type;
+            this.obj = obj;
+        }
+    }
+
+    ProviderDeleteVisitor(NodeVisitor parentWriter, List<String> deleteAuthorities, String ns, String name) {
+        this.parentWriter = parentWriter;
+        this.deleteAuthorities = deleteAuthorities;
+        this.elementNs = ns;
+        this.elementName = name;
+    }
+
+    @Override
+    public void line(int ln) {
+        lineNumber = ln;
+    }
+
+    @Override
+    public void attr(String ns, String name, int resourceId, int type, Object obj) {
+        if (decided && shouldDelete) {
+            return;
+        }
+
+        if (!decided && NodeValue.Application.Provider.AUTHORITIES.equals(name) && obj instanceof String) {
+            shouldDelete = isAuthorityMatched((String) obj);
+            decided = true;
+
+            if (shouldDelete) {
+                pendingAttrs.clear();
+                return;
+            }
+
+            ensureWriterCreated();
+            flushPendingAttrs();
+            writerNode.attr(ns, name, resourceId, type, obj);
+            return;
+        }
+
+        if (!decided) {
+            pendingAttrs.add(new AttrRecord(ns, name, resourceId, type, obj));
+            return;
+        }
+
+        ensureWriterCreated();
+        writerNode.attr(ns, name, resourceId, type, obj);
+    }
+
+    @Override
+    public NodeVisitor child(String ns, String name) {
+        if (!decided) {
+            shouldDelete = false;
+            decided = true;
+            ensureWriterCreated();
+            flushPendingAttrs();
+        }
+
+        if (shouldDelete) {
+            return null;
+        }
+        return writerNode == null ? null : writerNode.child(ns, name);
+    }
+
+    @Override
+    public void end() {
+        if (!decided) {
+            shouldDelete = false;
+            decided = true;
+            ensureWriterCreated();
+            flushPendingAttrs();
+        }
+
+        if (!shouldDelete && writerNode != null) {
+            writerNode.end();
+        }
+    }
+
+    private boolean isAuthorityMatched(String authorities) {
+        for (String deleteAuthority : deleteAuthorities) {
+            if (deleteAuthority.equals(authorities)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void ensureWriterCreated() {
+        if (writerNode == null) {
+            writerNode = parentWriter.child(elementNs, elementName);
+            if (lineNumber >= 0) {
+                writerNode.line(lineNumber);
+            }
+        }
+    }
+
+    private void flushPendingAttrs() {
+        for (AttrRecord pendingAttr : pendingAttrs) {
+            writerNode.attr(pendingAttr.ns, pendingAttr.name, pendingAttr.resourceId, pendingAttr.type, pendingAttr.obj);
+        }
+        pendingAttrs.clear();
+    }
+}


### PR DESCRIPTION
## Summary

This PR improves two manifest editing flows:

1. refines activity add/replace behavior
2. adds provider deletion support by exact `android:authorities` match

It also updates the CLI wording and README so the documented behavior matches the current implementation.

## Activity changes

The activity handling flow is cleaned up to make add-vs-replace behavior more explicit.

### Behavior
- `-act activity-name[:exported]` can add a new activity node
- if an activity with the same name already exists, the visitor updates supported fields on the existing node
- currently, the supported fields are limited to:
  - `android:name`
  - `android:exported`

### Why
The previous implementation had overlapping state and replacement logic, which made the flow harder to follow and maintain. This change simplifies the control flow while keeping the supported behavior focused and predictable.

## Provider changes

This PR adds provider deletion support through `deleteProviderAuthorities`.

### Behavior
- callers can register one or more provider authorities to delete
- when visiting existing `<provider>` nodes, a provider is removed if its `android:authorities` exactly matches one of those configured values

### Why
This enables delete-then-add semantics for injected providers and helps avoid duplicate provider nodes during repeated manifest patching.

## Other updates

- update `ManifestEditorMain` option description for `-act`
- update `README` wording to reflect that activity handling supports both add and replace
- clarify that activity support is intentionally limited to `name` and `exported`

## Notes

- provider matching is intentionally based on exact `android:authorities` equality
- activity replacement remains intentionally minimal and does not try to rewrite arbitrary nested activity configuration

## Downstream use case

In NPatch, this is used together with:
- manifest `meta-data` replacement instead of blind append
- authority remapping when the package name changes
- provider reinjection with delete-then-add semantics

This ensures repeated patching does not accumulate duplicate `meta-data` or duplicate `provider` entries.