### PR TITLE
Support typed provider attributes and fix emui AXML line numbers

### DIFF
--- a/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
+++ b/lib/src/main/java/com/wind/meditor/property/ModificationProperty.java
@@ -1,7 +1,6 @@
 package com.wind.meditor.property;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -43,8 +42,8 @@ public class ModificationProperty {
         return this;
     }
 
-    public ModificationProperty addProvider(HashMap<String,String> nameValue,String filterNameValue){
-        providerList.add(new Provider(nameValue,filterNameValue));
+    public ModificationProperty addProvider(List<AttributeItem> attributes, String filterAction){
+        providerList.add(new Provider(attributes, filterAction));
         return this;
     }
 
@@ -146,18 +145,27 @@ public class ModificationProperty {
         }
     }
 
+    /**
+     * A {@code <provider>} to add, carried as typed {@link AttributeItem}s rather than string pairs.
+     *
+     * The type matters: {@code exported} and {@code grantUriPermissions} are read by the platform
+     * with {@code TypedArray.getBoolean}, which returns the default for any non-integer value -- so a
+     * boolean written as the string {@code "true"} is silently seen as false. Passing an
+     * {@link AttributeItem} whose value is a {@link Boolean} lets the visitor emit it as
+     * {@code TYPE_INT_BOOLEAN}, which the platform actually honours.
+     */
     public static class Provider{
-        private HashMap<String,String> nameValue;
-        private String filterNameValue;
-        public Provider(HashMap<String,String> nameValue,String filterNameValue){
-            this.nameValue = nameValue;
-            this.filterNameValue = filterNameValue;
+        private final List<AttributeItem> attributes;
+        private final String filterAction;
+        public Provider(List<AttributeItem> attributes, String filterAction){
+            this.attributes = attributes;
+            this.filterAction = filterAction;
         }
-        public HashMap<String,String> getNameValue(){
-            return nameValue;
+        public List<AttributeItem> getAttributes(){
+            return attributes;
         }
-        public String getFilterNameValue(){
-            return filterNameValue;
+        public String getFilterAction(){
+            return filterAction;
         }
     }
 

--- a/lib/src/main/java/com/wind/meditor/visitor/ProviderVisitor.java
+++ b/lib/src/main/java/com/wind/meditor/visitor/ProviderVisitor.java
@@ -10,24 +10,16 @@ import pxb.android.axml.NodeVisitor;
 
 public class ProviderVisitor extends ModifyAttributeVisitor{
     ProviderVisitor(NodeVisitor nv, ModificationProperty.Provider provider) {
-        super(nv, convertToAttr(provider), true);
+        super(nv, provider == null ? null : provider.getAttributes(), true);
 
-        NodeVisitor intentFilter = super.child(null, "intent-filter");
-        NodeVisitor action = intentFilter.child(null, "action");
+        String filterAction = provider == null ? null : provider.getFilterAction();
+        if (filterAction != null) {
+            NodeVisitor intentFilter = super.child(null, "intent-filter");
+            NodeVisitor action = intentFilter.child(null, "action");
 
-        List<AttributeItem> list = new ArrayList<>();
-        list.add(new AttributeItem("name", provider.getFilterNameValue()));
-        new ModifyAttributeVisitor(action, list,true);
-    }
-
-    private static List<AttributeItem> convertToAttr(ModificationProperty.Provider provider) {
-        if (provider == null) {
-            return null;
+            List<AttributeItem> list = new ArrayList<>();
+            list.add(new AttributeItem("name", filterAction));
+            new ModifyAttributeVisitor(action, list, true);
         }
-        ArrayList<AttributeItem> list = new ArrayList<>();
-        for (String keys : provider.getNameValue().keySet()){
-           list.add(new AttributeItem(keys, provider.getNameValue().get(keys)));
-        }
-        return list;
     }
 }

--- a/lib/src/main/java/pxb/android/axml/AxmlWriter.java
+++ b/lib/src/main/java/pxb/android/axml/AxmlWriter.java
@@ -215,7 +215,7 @@ public class AxmlWriter extends AxmlVisitor {
             // start tag
             out.putInt(RES_XML_START_ELEMENT_TYPE | (0x0010 << 16));
             out.putInt(36 + attrs.size() * 20);
-            out.putInt(line);
+            out.putInt(line > 0 ? line : 1);
             out.putInt(0xFFFFFFFF);
             out.putInt(ns != null ? this.ns.index : -1);
             out.putInt(name.index);
@@ -271,7 +271,7 @@ public class AxmlWriter extends AxmlVisitor {
             // end tag
             out.putInt(RES_XML_END_ELEMENT_TYPE | (0x0010 << 16));
             out.putInt(24);
-            out.putInt(-1);
+            out.putInt(line > 0 ? line : 1);
             out.putInt(0xFFFFFFFF);
             out.putInt(ns != null ? this.ns.index : -1);
             out.putInt(name.index);
@@ -392,7 +392,7 @@ public class AxmlWriter extends AxmlVisitor {
             stack.push(ns);
             out.putInt(RES_XML_START_NAMESPACE_TYPE | (0x0010 << 16));
             out.putInt(24);
-            out.putInt(-1);
+            out.putInt(1);
             out.putInt(0xFFFFFFFF);
             out.putInt(ns.prefix.index);
             out.putInt(ns.uri.index);
@@ -406,7 +406,7 @@ public class AxmlWriter extends AxmlVisitor {
             Ns ns = stack.pop();
             out.putInt(RES_XML_END_NAMESPACE_TYPE | (0x0010 << 16));
             out.putInt(24);
-            out.putInt(ns.ln);
+            out.putInt(ns.ln > 0 ? ns.ln : 1);
             out.putInt(0xFFFFFFFF);
             out.putInt(ns.prefix.index);
             out.putInt(ns.uri.index);


### PR DESCRIPTION
Merge JingMatrix fixes for TypedArray and always output positive AXML line numbers to prevent Android PackageInstaller from rejecting modified Manifests on strict OS environments (like EMUI).